### PR TITLE
Created basic pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61.0", "numpy>=1.12"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Created a very basic `pyproject.toml`, so that it is possible to install the package with e.g. `poetry`.

Previously, the following error was raised:
```
ChefBuildError Backend subprocess exited when trying to invoke get_requires_for_build_wheel
```